### PR TITLE
Update plugins version to avoid Maven AetherClassNotFound bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 	      <plugin>
 	      	<groupId>org.apache.maven.plugins</groupId>
 		    <artifactId>maven-source-plugin</artifactId>
-	        <version>2.1.2</version>
+	        <version>3.0.1</version>
 	        <executions>
 	          <execution>
 	            <id>attach-sources</id>
@@ -41,7 +41,7 @@
 	      </plugin>
 	      <plugin>
 		     <artifactId>maven-compiler-plugin</artifactId>
-		     <version>2.3.2</version>
+		     <version>3.6.1</version>
 		     <configuration>
 		       <source>1.6</source>
 		       <target>1.6</target>
@@ -57,7 +57,7 @@
 	      <plugin>
 	        <groupId>org.codehaus.mojo</groupId>
 	        <artifactId>build-helper-maven-plugin</artifactId>
-	        <version>1.5</version>
+	        <version>3.0.0</version>
 	        <executions>
 	          <execution>
 	            <id>add-resource</id>
@@ -79,7 +79,7 @@
 	      <plugin>
 	        <groupId>org.apache.maven.plugins</groupId>
 	        <artifactId>maven-shade-plugin</artifactId>
-	        <version>2.0</version>
+	        <version>3.0.0</version>
 	        <executions>
 	          <execution>
 	            <goals>


### PR DESCRIPTION
https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound

Signed-off-by: Marc-Aurèle Brothier <m@brothier.org>